### PR TITLE
STRICT_R_HEADERS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
   the `rxode2` internals use the function pointers, while the models
   built by `rxode2` use the binary linkage.
 
+* As requested by `CRAN` use strict headers.
+
 # PreciseSums 0.6
 
 * Updated linkage for C.

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,3 @@
+PKG_CFLAGS  = -DSTRICT_R_HEADERS=1
 SOURCES_C = sum.c prod.c init.c
 OBJECTS = $(SOURCES_C:.c=.o)

--- a/src/PreciseSums.h
+++ b/src/PreciseSums.h
@@ -11,6 +11,7 @@
 #define PS_Prod 2
 #define PS_LogifyProd 3
 
+#define R_NO_REMAP
 #include <R.h>
 #include <Rinternals.h>
 #include <Rdefines.h>

--- a/src/PreciseSumsPtr.h
+++ b/src/PreciseSumsPtr.h
@@ -11,6 +11,7 @@
 #define PS_Prod 2
 #define PS_LogifyProd 3
 
+#define R_NO_REMAP
 #include <R.h>
 #include <Rinternals.h>
 #include <Rdefines.h>

--- a/src/init.c
+++ b/src/init.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#define R_NO_REMAP
 #include <R.h>
 #include <Rinternals.h>
 #include <Rmath.h> //Rmath includes math.
@@ -40,7 +41,7 @@ SEXP _PreciseSumsPtr(void) {
   SEXP PreciseSums_sum_get_ptr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&PreciseSums_sum_get, R_NilValue, R_NilValue)); pro++;
   SEXP PreciseSums_prod_get_ptr = PROTECT(R_MakeExternalPtrFn((DL_FUNC)&PreciseSums_prod_get, R_NilValue, R_NilValue)); pro++;
 
-  SEXP ret = PROTECT(allocVector(VECSXP, 6)); pro++;
+  SEXP ret = PROTECT(Rf_allocVector(VECSXP, 6)); pro++;
   SET_VECTOR_ELT(ret, 0, PreciseSums_sum_ptr);
   SET_VECTOR_ELT(ret, 1, PreciseSums_prod_ptr);
   SET_VECTOR_ELT(ret, 2, PreciseSums_sum_r_ptr);
@@ -48,15 +49,15 @@ SEXP _PreciseSumsPtr(void) {
   SET_VECTOR_ELT(ret, 4, PreciseSums_sum_get_ptr);
   SET_VECTOR_ELT(ret, 5, PreciseSums_prod_get_ptr);
 
-  SEXP retn = PROTECT(allocVector(STRSXP, 6)); pro++;
-  SET_STRING_ELT(retn, 0, mkChar("PreciseSums_sum"));
-  SET_STRING_ELT(retn, 1, mkChar("PreciseSums_prod"));
-  SET_STRING_ELT(retn, 2, mkChar("PreciseSums_sum_r"));
-  SET_STRING_ELT(retn, 3, mkChar("PreciseSums_prod_r"));
-  SET_STRING_ELT(retn, 4, mkChar("PreciseSums_sum_get"));
-  SET_STRING_ELT(retn, 5, mkChar("PreciseSums_prod_get"));
+  SEXP retn = PROTECT(Rf_allocVector(STRSXP, 6)); pro++;
+  SET_STRING_ELT(retn, 0, Rf_mkChar("PreciseSums_sum"));
+  SET_STRING_ELT(retn, 1, Rf_mkChar("PreciseSums_prod"));
+  SET_STRING_ELT(retn, 2, Rf_mkChar("PreciseSums_sum_r"));
+  SET_STRING_ELT(retn, 3, Rf_mkChar("PreciseSums_prod_r"));
+  SET_STRING_ELT(retn, 4, Rf_mkChar("PreciseSums_sum_get"));
+  SET_STRING_ELT(retn, 5, Rf_mkChar("PreciseSums_prod_get"));
 
-  setAttrib(ret, R_NamesSymbol, retn);
+  Rf_setAttrib(ret, R_NamesSymbol, retn);
 
   UNPROTECT(pro);
   return ret;


### PR DESCRIPTION
Dear maintainer,

Please see the problems shown on
<https://cran.r-project.org/web/checks/check_results_PreciseSums.html>.

Specifically, please see the *Strict* additional issue.

Compilation fails with _R_USE_STRICT_R_HEADERS_=true, which defines
STRICT_R_HEADERS to 1 which removes

- the legacy definition of PI (use POSIX's M_PI, available in R fer ever).
- the RS.h declarations for Calloc, Realloc, Free (use R_ forms i
  available since R 3.4.0).

The aim is to clean the namespace: in particular having a definition
for Free has conflicted with some packages' C++ code.

It is planned that STRICT_R_HEADERS=1 will become the default for 4.5.0,
which in particular makes it necesssary that all CRAN packages with many
strong reverse dependencies compile/install ok with the new default.

Your package is among the ones with many strong reverse dependencies.
We would thus really appreciate if you could provide a new version of
your package as soon as possible which checks ok with
STRICT_R_HEADERS=1.

You can verify that your package checks ok with STRICT_R_HEADERS=1 via R
CMD check --as-cran using a current version of R-devel.

Please correct before 2024-09-20 to safely retain your package on CRAN.
